### PR TITLE
Adding repository information to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,9 @@
   "devDependencies": {
     "coffee-script": "^1.9.1",
     "protolog": "0.0.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thejsj/livedb-rethinkdb"
   }
 }


### PR DESCRIPTION
Awesome project!

This just gets rid of the npm warning:

```
$ npm install
npm WARN package.json livedb-rethinkdb@0.0.5 No repository field.
```
